### PR TITLE
Add GitHub Actions workflow for Jekyll build

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,18 @@
+name: Jekyll Build
+
+on:
+  pull_request:
+  push:
+    branches: ["master", "main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the Jekyll site on pull requests and pushes

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d92ba9a048330b8587c9b6fdc5450