### PR TITLE
Fix comments config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -311,7 +311,7 @@ defaults:
       layout: single
       author_profile: false
       share: true
-      coment: true
+      comments: true
   # _experience
   - scope:
       path: ""
@@ -320,4 +320,4 @@ defaults:
       layout: single
       author_profile: false
       share: true
-      coment: true
+      comments: true


### PR DESCRIPTION
## Summary
- fix typo so collection configs enable comments

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'github-pages' in locally installed gems.)*


------
https://chatgpt.com/codex/tasks/task_b_685d929f001c8330935959cd871340e8